### PR TITLE
Upgrade deep-assign to 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "azure-sb": "^0.10.2",
     "body-parser": "^1.13.1",
-    "deep-assign": "^1.0.0",
+    "deep-assign": "^2.0.0",
     "es6-promise": "^2.1.1",
     "express": "^4.12.4",
     "jsonwebtoken": "^5.0.2",


### PR DESCRIPTION
Update deep-assign to 2.0.0 because prior version has a bug - function as value is transform to empty object.