### PR TITLE
Add partial support for converting OData to SQLite

### DIFF
--- a/src/data/sql/execute.js
+++ b/src/data/sql/execute.js
@@ -7,7 +7,7 @@ var mssql = require('mssql'),
     log = require('../../logger'),
     connection;
 
-module.exports = function (config, statement) {
+module.exports = function (config, sql) {
     // for some reason, creating a new connection object for each request hangs on the second request when hosted
     // not sure if this will have any effect on performance, i.e. does each request have to wait for the last to complete?
     if(!connection) {
@@ -24,21 +24,39 @@ module.exports = function (config, statement) {
     function executeRequest() {
         var request = new mssql.Request(connection);
 
-        request.multiple = statement.multiple;
-
-        if(statement.parameters) {
-            statement.parameters.forEach(function (parameter) {
-                var type = parameter.type || helpers.getMssqlType(parameter.value);
-                if(type)
-                    request.input(parameter.name, type, parameter.value);
-                else
-                    request.input(parameter.name, parameter.value);
-            });
+        var statements = sql;
+        if (sql.constructor !== Array) {
+            statements = [sql];
         }
+        
+        // We expect multiple results if there are multiple statements to be executed or if
+        // 'multiple' results are explicitly requested
+        request.multiple = statements.length > 1 ||  statements[0].multiple;
+        
+        var statement = '',
+            params = [];
+        
+        // Combine the statements into a single statement
+        statements.forEach(function(st) {
+            statement += st.sql + '; ';
+            
+            if (st.parameters) {
+                params = params.concat(st.parameters)
+            }
+        });
+        
+        // Combine the parameter lists into a single list
+        params.forEach(function (parameter) {
+            var type = parameter.type || helpers.getMssqlType(parameter.value);
+            if(type)
+                request.input(parameter.name, type, parameter.value);
+            else
+                request.input(parameter.name, parameter.value);
+        });
 
-        log.verbose('Executing SQL statement ' + statement.sql + ' with parameters ' + JSON.stringify(statement.parameters));
-        return request.query(statement.sql).catch(function (err) {
-            log.debug('SQL statement failed - ' + err.message + ': ' + statement.sql + ' with parameters ' + JSON.stringify(statement.parameters));
+        log.verbose('Executing SQL statement ' + statement + ' with parameters ' + JSON.stringify(params));
+        return request.query(statement).catch(function (err) {
+            log.debug('SQL statement failed - ' + err.message + ': ' + statement + ' with parameters ' + JSON.stringify(params));
             if(err.number === 2627) {
                 var error = new Error('An item with the same ID already exists');
                 error.duplicate = true;

--- a/src/data/sql/helpers.js
+++ b/src/data/sql/helpers.js
@@ -39,10 +39,16 @@ var helpers = module.exports = {
     },
 
     formatTableName: function (schemaName, tableName) {
-        schemaName = module.exports.formatSchemaName(schemaName);
-        this.validateIdentifier(schemaName);
+        
         this.validateIdentifier(tableName);
-        return '[' + schemaName + '].[' + tableName + ']';
+
+        if (schemaName !== undefined) {
+            schemaName = module.exports.formatSchemaName(schemaName);
+            this.validateIdentifier(schemaName);
+            return '[' + schemaName + '].[' + tableName + ']';
+        }
+        
+        return tableName;
     },
 
     formatSchemaName: function (appName) {


### PR DESCRIPTION
- Not all queries will generate sqlite yet. More work needs to be done before we get there.
- SQLFormatter's format method now returns an array of sql statements. The statements can be merged into a single statement according to the sql flavor being used.