### PR TITLE
adding custom api routes feature

### DIFF
--- a/samples/customApi/api/custom.js
+++ b/samples/customApi/api/custom.js
@@ -1,12 +1,35 @@
-var middleware = require('customMiddleware');
 
 var api = module.exports = {
-    get: [customMiddleware, function (req, res, next) {
-        next()
-    }],
-    post: [customMiddleware, function (req, res, next) {
-        next()
-    }]
+
+    getAchievement: function(req, res, next){
+        // var achievementName = req.params.achievementName;
+        // var gameId = +req.params.gameId;
+        res.status(200).end();
+    },
+    setAchievement: function (req, res, next){
+        // var achievementName = req.params.achievementName;
+        // var gameId = +req.params.gameId;
+        res.status(200).end();
+    },
+    get: function (req, res, next) {
+        res.status(200).end();
+    },
+    put: [function(req, res, next) {
+            res.set('customapi', 'true');
+            next();
+        },function (req, res, next) {
+            res.status(200).end();
+        }],
+    delete: function(req, res, next) {
+        res.status(200).end();
+    },
 }
 
-api.get.authorize = true;
+api.getAchievement.get = '/:gameId/get/:achievementName';
+api.setAchievement.post = '/:gameId/set/:achievementName';
+
+api.getAchievement.authorize = true;
+// api.get.authorize = true;
+// api.delete.authorize = true;
+// api.put.authorize = true;
+

--- a/samples/customApi/app.js
+++ b/samples/customApi/app.js
@@ -2,4 +2,5 @@ var app = require('express')(),
     mobileApp = require('azure-mobile-apps')()
 
 mobileApp.api.import('api')
-mobileApp.api.use()
+app.use(mobileApp);    // Register the Azure Mobile Apps middleware
+app.listen(process.env.PORT || 3000); 


### PR DESCRIPTION
Here is a proposition for custom routing on api system.
There is no breaking changes from the current version and how it currently works.

Basically, the idea is to provide :
* Severals functions side by side with the verbs (get, post, put, delete) functions, 
* Affect properties (in the same way than authorization) to set the custom routing path for those functions

I have tries many possibilities and made many tests on different implementations and it seems (at least for me) that this implementation is the most efficient and the most straightforward.
And of course keep in mind that it doesn't break anything on the current API implementation.
