### PR TITLE
Minor api refactor

### DIFF
--- a/src/express/api/index.js
+++ b/src/express/api/index.js
@@ -14,8 +14,7 @@ var express = require('express'),
     notAllowed = require('../middleware/notAllowed'),
     utilities = require('../../utilities'),
     types = require('../../utilities/types'),
-    importDefinition = require('../../configuration/importDefinition'),
-    supportedVerbs = ['get', 'post', 'put', 'patch', 'delete'];
+    importDefinition = require('../../configuration/importDefinition');
 
 /**
 Create an instance of an express router for routing and handling api requests.
@@ -53,7 +52,7 @@ module.exports = function (configuration) {
         Object.getOwnPropertyNames(definition).forEach(function (method) {
             var middleware = getDefinedMiddleware(definition[method]);
             if (types.isFunction(middleware) || types.isArray(middleware)) {
-                if (isSupportedVerb(method)) {
+                if (supportsVerb(method)) {
                     logger.verbose("Adding method " + method + " to api " + definition.name);
                     apiRouter[method]('/', configureMiddleware(definition, method, middleware));
                 } else {
@@ -89,7 +88,7 @@ module.exports = function (configuration) {
         return utilities.object.convertArrayLike(methodDefinition);
     }
 
-    function isSupportedVerb(verb) {
-        return supportedVerbs.some(function (supportedVerb) { return supportedVerb === verb; });
+    function supportsVerb(verb) {
+        return !!router[verb] && types.isFunction(router[verb]);
     }
 }

--- a/src/utilities/object.js
+++ b/src/utilities/object.js
@@ -1,6 +1,8 @@
 // ----------------------------------------------------------------------------
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
+var types = require('./types');
+
 module.exports = {
     values: function (source) {
         return Object.keys(source).map(function (property) {
@@ -11,12 +13,14 @@ module.exports = {
     // if array-like object convert to array
     // {'0': addHeader, '1': return200, authorize: true} should convert to [addHeader,return200]
     convertArrayLike: function (arrayLikeObject) {
-        var length = 0;
-        while (arrayLikeObject.hasOwnProperty(length))
-            length++;
-        if (length) {
-            arrayLikeObject.length = length;
-            arrayLikeObject = Array.prototype.slice.call(arrayLikeObject);
+        if (types.isObject(arrayLikeObject)) {
+            var length = 0;
+            while (arrayLikeObject.hasOwnProperty(length))
+                length++;
+            if (length) {
+                arrayLikeObject.length = length;
+                arrayLikeObject = Array.prototype.slice.call(arrayLikeObject);
+            }
         }
         return arrayLikeObject;
     }

--- a/test/express/files/api/customapi.js
+++ b/test/express/files/api/customapi.js
@@ -5,9 +5,6 @@ var api = module.exports = {
     put: [ addHeader, send ],
     delete: function(req, res, next) {
         res.status(200).end();
-    },
-    trace: function(req, res, next) {
-        res.status(500).end();
     }
 };
 

--- a/test/express/integration/customapi.tests.js
+++ b/test/express/integration/customapi.tests.js
@@ -35,10 +35,6 @@ describe('azure-mobile-apps.express.integration.customapi', function () {
             .expect(200);
     });
 
-    it('returns 404 on unsupported verbs', function () {
-        return request(app).trace('/api/customapiname').expect(404);
-    });
-
     it('correctly imports middleware array', function () {
         return request(app).put('/api/customapiname')
             .set('x-zumo-auth', token)


### PR DESCRIPTION
Moved the conversion of array-like objects & added isSupportedVerb to improve readability & facilitate better warning of unsupported methods.

Basically, split the definition middleware process into 4 parts:  build the user defined middleware (getting around the array like object issue), determine whether that middleware should be attached, configure the middleware with disable/authorize, then attach.