### PR TITLE
Configuration changes

### DIFF
--- a/src/configuration/fromEnvironment.js
+++ b/src/configuration/fromEnvironment.js
@@ -6,71 +6,71 @@ var connectionString = require('./connectionString'),
     assign = require('deeply');
 
 // determine various configuration information from environment such as web.config settings, etc.
-module.exports = function (configuration) {
-    Object.keys(process.env).forEach(function (key) {
+module.exports = function (configuration, environment) {
+    Object.keys(environment).forEach(function (key) {
         switch(key.toLowerCase()) {
             case 'ms_mobileloglevel':
-                configuration.logging.level = process.env[key];
+                configuration.logging.level = environment[key];
                 break;
 
             case 'sqlconnstr_ms_tableconnectionstring':
             case 'sqlazureconnstr_ms_tableconnectionstring':
             case 'ms_tableconnectionstring':
-                configuration.data = assign(configuration.data, connectionString.parse(process.env[key]));
+                configuration.data = assign(configuration.data || {}, connectionString.parse(environment[key]));
                 break;
 
             case 'ms_databaseschemaname':
-                configuration.data.schema = process.env[key];
+                configuration.data.schema = environment[key];
                 break;
 
             case 'ms_dynamicschema':
-                configuration.data.dynamicSchema = parseBoolean(process.env[key]);
+                configuration.data.dynamicSchema = parseBoolean(environment[key]);
                 break;
 
             case 'ema_runtimeurl':
-                configuration.auth.gatewayUrl = process.env[key];
+                configuration.auth.gatewayUrl = environment[key];
                 break;
 
             case 'website_auth_signing_key':
-                configuration.auth.secret = process.env[key];
+                configuration.auth.secret = environment[key];
                 break;
 
             case 'ms_mobileappname':
             case 'ms_mobileservicename':
-                configuration.name = process.env[key];
+                configuration.name = environment[key];
                 break;
 
             case 'ms_crossdomainwhitelist':
-                process.env[key].split(',').forEach(function (origin) {
+                environment[key].split(',').forEach(function (origin) {
                     configuration.cors.origins.push(origin);
                 });
                 break;
 
             case 'ms_notificationhubname':
-                configuration.notifications.hubName = process.env[key];
+                configuration.notifications.hubName = environment[key];
                 break;
 
             case 'customconnstr_ms_notificationhubconnectionstring':
             case 'ms_notificationhubconnectionstring':
-                configuration.notifications.connectionString = process.env[key];
+                configuration.notifications.connectionString = environment[key];
                 break;
 
             case 'ms_debugmode':
-                configuration.debug = parseBoolean(process.env[key]);
+                configuration.debug = parseBoolean(environment[key]);
                 break;
 
             case 'ms_disableversionheader':
-                if(parseBoolean(process.env[key]))
+                if(parseBoolean(environment[key]))
                     configuration.version = undefined;
                 break;
 
             case 'ms_skipversioncheck':
-                configuration.skipVersionCheck = parseBoolean(process.env[key]);
+                configuration.skipVersionCheck = parseBoolean(environment[key]);
                 break;
 
             case 'website_hostname':
-                configuration.auth.audience = 'https://' + process.env[key] + '/';
-                configuration.auth.issuer = 'https://' + process.env[key] + '/';
+                configuration.auth.audience = 'https://' + environment[key] + '/';
+                configuration.auth.issuer = 'https://' + environment[key] + '/';
                 break;
         }
     });
@@ -79,5 +79,6 @@ module.exports = function (configuration) {
 };
 
 function parseBoolean(value) {
-    return value && value.toLowerCase() === 'true' || value === '1';
+    return (value === true) ||
+        (value && value.toLowerCase() === 'true' || value === '1');
 }

--- a/src/index.js
+++ b/src/index.js
@@ -55,14 +55,15 @@ var loadConfiguration = require('./configuration'),
 /**
 Creates an instance of the azure-mobile-apps server object for the platform specified in the configuration.
 Express 4.x is currently the only supported platform.
-@param {configuration} configuration
+@param {configuration} configuration Top level configuration for all aspects of the mobile app
+@param {object} environment=process.env An object containing the environment to load configuration from
 @returns {module:azure-mobile-apps/express}
 */
-module.exports = function (configuration) {
+module.exports = function (configuration, environment) {
     configuration = configuration || {};
     var configFile = path.resolve(configuration.basePath || defaults.basePath, configuration.configFile || defaults.configFile);
     configuration = assign({ logging: {}, data: {}, auth: {} }, defaults, loadConfiguration.fromFile(configFile), configuration);
-    loadConfiguration.fromEnvironment(configuration);
+    loadConfiguration.fromEnvironment(configuration, environment || process.env);
     loadConfiguration.fromSettingsJson(configuration);
 
     return platforms[configuration.platform](configuration);

--- a/test/data/sql/infrastructure/config.js
+++ b/test/data/sql/infrastructure/config.js
@@ -2,8 +2,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
+debugger;
+
 // we can expand this to provide different configurations for different environments
 var configuration = require('../../../../src/configuration'),
     path = require('path');
 
-module.exports = configuration.fromEnvironment(configuration.fromFile(path.resolve(__dirname, '../../../config.js'))).data;
+module.exports = configuration.fromEnvironment(configuration.fromFile(path.resolve(__dirname, '../../../config.js')), process.env).data;

--- a/test/data/sql/infrastructure/config.js
+++ b/test/data/sql/infrastructure/config.js
@@ -2,8 +2,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ----------------------------------------------------------------------------
 
-debugger;
-
 // we can expand this to provide different configurations for different environments
 var configuration = require('../../../../src/configuration'),
     path = require('path');

--- a/test/express/infrastructure/config.js
+++ b/test/express/infrastructure/config.js
@@ -7,7 +7,7 @@ var configuration = require('../../../src/configuration'),
     path = require('path');
 
 var api = module.exports = function () {
-    var config = configuration.fromEnvironment(configuration.fromFile(path.resolve(__dirname, '../../config.js')));
+    var config = configuration.fromEnvironment(configuration.fromFile(path.resolve(__dirname, '../../config.js')), process.env);
     config.basePath = __dirname;
     return config;
 }

--- a/test/express/integration/middleware.tests.js
+++ b/test/express/integration/middleware.tests.js
@@ -4,20 +4,12 @@
 var expect = require('chai').expect,
     supertest = require('supertest-as-promised'),
     app = require('express')(),
-    mobileApp,
-    oldConnectionString = process.env.MS_TableConnectionString;
+    mobileApp;
 
 describe('azure-mobile-apps.express.integration.middleware', function () {
     before(function () {
-        // environment settings override configured settings - hack to force use of the memory provider
-        delete process.env.MS_TableConnectionString;
-        mobileApp = require('../../..')({ skipVersionCheck: true })
+        mobileApp = require('../../..')({ skipVersionCheck: true }, {})
     });
-
-    after(function () {
-        if(oldConnectionString)
-            process.env.MS_TableConnectionString = oldConnectionString;
-    })
 
     it('read middleware is mounted in the correct order', function () {
         return test('read', 'get');

--- a/test/express/integration/tables.behavior.tests.js
+++ b/test/express/integration/tables.behavior.tests.js
@@ -6,25 +6,14 @@
     express = require('express'),
     bodyParser = require('body-parser'),
     mobileApps = require('../../../src'),
-    connectionString,
 
     app, mobileApp;
 
 // the default configuration uses the in-memory data provider - it does not (yet) support queries
 describe('azure-mobile-apps.express.integration.tables.behavior', function () {
-    before(function () {
-        connectionString = process.env.MS_TableConnectionString;
-        delete process.env.MS_TableConnectionString;
-    });
-
-    after(function () {
-        if (connectionString)
-            process.env.MS_TableConnectionString = connectionString;
-    });
-
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ skipVersionCheck: true, logging: false });
+        mobileApp = mobileApps({ skipVersionCheck: true, logging: false }, {});
     });
 
     it('returns 200 for table route', function () {

--- a/test/express/integration/tables.etag.tests.js
+++ b/test/express/integration/tables.etag.tests.js
@@ -5,25 +5,14 @@
     supertest = require('supertest-as-promised'),
     express = require('express'),
     mobileApps = require('../../../src'),
-    connectionString,
 
     app, mobileApp;
 
 // the default configuration uses the in-memory data provider - it does not (yet) support queries
 describe('azure-mobile-apps.express.integration.tables.etag', function () {
-    before(function () {
-        connectionString = process.env.MS_TableConnectionString;
-        delete process.env.MS_TableConnectionString;
-    });
-
-    after(function () {
-        if (connectionString)
-            process.env.MS_TableConnectionString = connectionString;
-    });
-    
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ pageSize: 2, skipVersionCheck: true });
+        mobileApp = mobileApps({ pageSize: 2, skipVersionCheck: true }, {});
         var table = mobileApps.table();
         table.read(function (context) {
             return [{

--- a/test/express/integration/tables.link.tests.js
+++ b/test/express/integration/tables.link.tests.js
@@ -5,29 +5,18 @@
     supertest = require('supertest-as-promised'),
     express = require('express'),
     mobileApps = require('../../../src'),
-    connectionString,
 
     app, mobileApp;
 
 // the default configuration uses the in-memory data provider - it does not (yet) support queries
 describe('azure-mobile-apps.express.integration.tables.link', function () {
-    before(function () {
-        connectionString = process.env.MS_TableConnectionString;
-        delete process.env.MS_TableConnectionString;
-    });
-
-    after(function () {
-        if (connectionString)
-            process.env.MS_TableConnectionString = connectionString;
-    });
-
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ pageSize: 2, skipVersionCheck: true });
+        mobileApp = mobileApps({ pageSize: 2, skipVersionCheck: true }, {});
     });
 
     it('adds Link header when top > pageSize & results.length === pageSize', function () {
-        mobileApp = mobileApps({ pageSize: 1, skipVersionCheck: true });
+        mobileApp = mobileApps({ pageSize: 1, skipVersionCheck: true }, {});
         mobileApp.tables.add('headers');
         app.use(mobileApp);
         return supertest(app)

--- a/test/express/integration/version.tests.js
+++ b/test/express/integration/version.tests.js
@@ -5,24 +5,13 @@ var expect = require('chai').expect,
     supertest = require('supertest-as-promised'),
     express = require('express'),
     mobileApps = require('../../..'),
-    connectionString,
-    
+
     app, mobileApp;
 
 describe('azure-mobile-apps.express.integration.version', function () {
-    before(function () {
-        connectionString = process.env.MS_TableConnectionString;
-        delete process.env.MS_TableConnectionString;
-    });
-
-    after(function () {
-        if (connectionString)
-            process.env.MS_TableConnectionString = connectionString;
-    });
-
     it('attaches server version header', function () {
         app = express();
-        mobileApp = mobileApps({ skipVersionCheck: true });
+        mobileApp = mobileApps({ skipVersionCheck: true }, {});
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -33,7 +22,7 @@ describe('azure-mobile-apps.express.integration.version', function () {
 
     it('does not attach version header if version is set to undefined', function() {
         app = express();
-        mobileApp = mobileApps({ version: undefined, skipVersionCheck: true });
+        mobileApp = mobileApps({ version: undefined, skipVersionCheck: true }, {});
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -45,10 +34,8 @@ describe('azure-mobile-apps.express.integration.version', function () {
     });
 
     it('does not attach version header if MS_DisableVersionHeader is specified', function() {
-        process.env.MS_DisableVersionHeader = 'true';
-
         app = express();
-        mobileApp = mobileApps({ skipVersionCheck: true });
+        mobileApp = mobileApps({ skipVersionCheck: true }, { MS_DisableVersionHeader: 'true' });
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -56,7 +43,6 @@ describe('azure-mobile-apps.express.integration.version', function () {
             .get('/tables/todoitem')
             .expect(function (res) {
                 expect(res.headers['x-zumo-version']).to.be.undefined;
-                delete process.env.MS_DisableVersionHeader;
             });
     });
 
@@ -106,18 +92,13 @@ describe('azure-mobile-apps.express.integration.version', function () {
     });
 
     it('ignores api version when MS_SkipVersionCheck environment setting is specified', function () {
-        process.env.MS_SkipVersionCheck = true;
-
         app = express();
-        mobileApp = mobileApps();
+        mobileApp = mobileApps(undefined, { MS_SkipVersionCheck: 'true' });
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
         return supertest(app)
             .get('/tables/todoitem')
-            .expect(200)
-            .then(function () {
-                delete process.env.MS_SkipVersionCheck;
-            });
+            .expect(200);
     });
 });


### PR DESCRIPTION
This adds an environment parameter to the top level factory function, allowing consumers to override the default behavior of taking environment variables from process.env. Much nasty code eliminated from tests.

This should allow CI tests to pass, but there are still some problems to be solved:

- the logger implementation should be moved to a factory module in utilities and the existing logger module expose a static instance. This allows the logger module to be tested without affecting the default instance. This may not by itself remove all the calls to logger.configure in tests, but at least some.
- promises - the existing pull request allows a substitute promise implementation specified in a file, but we need this to run in CI. Allow a command line argument interpreted by this test to specify implementation?
- data providers - we will want to run these tests against different data providers. A bigger challenge.