### PR TITLE
Added error message to 404 responses

### DIFF
--- a/src/express/middleware/handleError.js
+++ b/src/express/middleware/handleError.js
@@ -18,6 +18,8 @@ module.exports = function (configuration) {
             res.status(409).json(req.azureMobile.item);
         else if (err.badRequest)
             res.status(400).json(normaliseError(err));
+        else if (err.notFound)
+            res.status(404).json({ error: 'The item does not exist' });
         else {
             log.error(err);
             res.status(500).json(normaliseError(err));

--- a/src/express/middleware/renderResults.js
+++ b/src/express/middleware/renderResults.js
@@ -16,15 +16,15 @@ module.exports = function (req, res, next) {
                 if(res.results.recordsAffected === undefined || res.results.recordsAffected > 0)
                     res.status(200).json(res.results);
                 else
-                    res.status(404).end();
+                    next({ notFound: true });
             } else if(res.results.length > 0) {
                 res.status(200).json(res.results[0]);
             } else {
-                res.status(404).end();
+                next({ notFound: true });
             }
         } else {
             if(res.recordsAffected === 0)
-                res.status(404).end();
+                next({ notFound: true });
             else {
                 res.status(200).json(res.results);
             }


### PR DESCRIPTION
This keeps one test in the iOS E2E test suite happy, but also helps with debugging (i.e. we no longer need to open dev tools to see the response code)