### PR TITLE
Changed configuration of globals (promises, logging)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "sinon-as-promised": "4.0.0",
     "sinon-chai": "^2.8.0",
     "supertest": "^1.1.0",
-    "supertest-as-promised": "^2.0.1"
+    "supertest-as-promised": "^2.0.1",
+    "q": "^1.4.1"
   }
 }

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -39,7 +39,6 @@ var express = require('express'),
  */
 module.exports = function (configuration) {
     configuration = configuration || {};
-    log.configure(configuration.logging);
     var tableMiddleware = tables(configuration),
         apiMiddleware = customApi(configuration),
         customMiddlewareRouter = express.Router(),

--- a/src/index.js
+++ b/src/index.js
@@ -68,10 +68,16 @@ module.exports = function (configuration, environment) {
     configuration = merge({ logging: {}, data: {}, auth: {} }, defaults, loadConfiguration.fromFile(configFile), configuration);
     loadConfiguration.fromEnvironment(configuration, environment || process.env);
     loadConfiguration.fromSettingsJson(configuration);
-    
-    promises.setConstructor(configuration.promiseConstructor);
 
+    module.exports.configureGlobals(configuration);
+    
     return platforms[configuration.platform](configuration);
 };
+
+// encapsulates configuration of global modules to simplify test configuration
+module.exports.configureGlobals = function (configuration) {
+    logger.configure(configuration.logging);
+    promises.setConstructor(configuration.promiseConstructor);
+}
 
 module.exports.table = table;

--- a/test/data/sql/integration.concurrency.tests.js
+++ b/test/data/sql/integration.concurrency.tests.js
@@ -9,7 +9,6 @@ var config = require('./infrastructure/config'),
 
 describe('azure-mobile-apps.data.sql.integration.concurrency', function () {
     before(function () {
-        require('../../../src/logger').configure();
         operations = index(config)({ name: 'concurrency' });
     });
 

--- a/test/data/sql/integration.softDelete.tests.js
+++ b/test/data/sql/integration.softDelete.tests.js
@@ -10,7 +10,6 @@ var config = require('./infrastructure/config'),
 
 describe('azure-mobile-apps.data.sql.integration.softDelete', function () {
     before(function () {
-        require('../../../src/logger').configure();
         operations = index(config)({ name: 'softDelete', softDelete: true });
     });
 

--- a/test/express/infrastructure/config.js
+++ b/test/express/infrastructure/config.js
@@ -4,14 +4,52 @@
 
 // we can expand this to provide different configurations for different environments
 var configuration = require('../../../src/configuration'),
-    path = require('path');
+    path = require('path'),
+    winston = require('winston');
+    q = require('q');
 
 var api = module.exports = function () {
     var config = configuration.fromEnvironment(configuration.fromFile(path.resolve(__dirname, '../../config.js')), process.env);
     config.basePath = __dirname;
+    applyCommandLineArguments(config);
     return config;
 }
 
 api.data = function () {
     return api().data;
 };
+
+function applyCommandLineArguments(config) {
+    var args = process.argv.slice(2),
+        customArgs = {};
+
+    // filter for custom arguments
+    args.forEach(function (arg, index) { 
+        if (arg.slice(0, 3) === '---') {
+            customArgs[arg.slice(3)] = args[index + 1];
+        }
+    });
+
+    Object.keys(customArgs).forEach(function (property) {
+        switch (property) {
+            case 'logging.level':
+                config.logging = {
+                    level: customArgs[property],
+                    transports: [
+                        new (winston.transports.Console)({
+                            colorize: true,
+                            timestamp: true,
+                            showLevel: true
+                        })
+                    ]
+                };
+                break;
+
+            case 'promiseConstructor':
+                if (customArgs[property] === 'q') {
+                    config.promiseConstructor = q.Promise;
+                }
+                break;
+        }
+    });
+}

--- a/test/express/infrastructure/config.js
+++ b/test/express/infrastructure/config.js
@@ -5,18 +5,29 @@
 // we can expand this to provide different configurations for different environments
 var configuration = require('../../../src/configuration'),
     path = require('path'),
+    merge = require('deeply'),
     winston = require('winston');
     q = require('q');
 
-var api = module.exports = function () {
-    var config = configuration.fromEnvironment(configuration.fromFile(path.resolve(__dirname, '../../config.js')), process.env);
-    config.basePath = __dirname;
-    applyCommandLineArguments(config);
-    return config;
+// initialize configuration for testing
+var config = configuration.fromEnvironment(configuration.fromFile(path.resolve(__dirname, '../../config.js')), process.env);
+// default to skipping version check
+config.skipVersionCheck = true;
+// default to no logging
+config.logging = {};
+config.basePath = __dirname;
+applyCommandLineArguments(config);
+
+var api = module.exports = function (userSuppliedConfig) {
+    return merge(config, userSuppliedConfig);
 }
 
-api.data = function () {
-    return api().data;
+api.memory = function (userSuppliedConfig) {
+    return merge(config, { data: { provider: 'memory' }}, userSuppliedConfig);
+}
+
+api.data = function (userSuppliedDataConfig) {
+    return merge(config.data, userSuppliedDataConfig);
 };
 
 function applyCommandLineArguments(config) {

--- a/test/express/integration/api.tests.js
+++ b/test/express/integration/api.tests.js
@@ -3,7 +3,7 @@
 // ----------------------------------------------------------------------------
 var expect = require('chai').use(require('chai-subset')).expect,
     request = require('supertest-as-promised'),
-    config = require('../infrastructure/config')(),
+    config = require('../infrastructure/config'),
     express = require('express'),
     mobileApps = require('../../../src/express'),
     data = require('../../../src/data/mssql'),
@@ -13,7 +13,7 @@ var expect = require('chai').use(require('chai-subset')).expect,
 describe('azure-mobile-apps.express.integration.api', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ data: config });
+        mobileApp = mobileApps(config.memory());
     });
 
     it('exposes data access object through request object', function () {

--- a/test/express/integration/auth.tests.js
+++ b/test/express/integration/auth.tests.js
@@ -8,6 +8,7 @@ var expect = require('chai').expect,
     auth = require('../../../src/auth')({ secret: 'secret' }),
     secret = 'secret',
     token = auth.sign({ "sub": "Facebook:someuserid@hotmail.com" }),
+    config = require('../infrastructure/config'),
 
     app, mobileApp;
 
@@ -15,7 +16,7 @@ var expect = require('chai').expect,
 describe('azure-mobile-apps.express.integration.auth', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ auth: { secret: secret, getIdentity: getIdentity }, skipVersionCheck: true });
+        mobileApp = mobileApps(config.memory({ auth: { secret: secret, getIdentity: getIdentity } }));
     });
 
     it('returns 200 for table requests with valid auth token', function () {

--- a/test/express/integration/cors.tests.js
+++ b/test/express/integration/cors.tests.js
@@ -12,20 +12,19 @@ var expect = require('chai').expect,
     accessControlExposeHeadersHeader = 'Access-Control-Expose-Headers',
     accessControlMaxAgeHeader = 'Access-Control-Max-Age',
     expectedAllowedMethods = 'GET, PUT, PATCH, POST, DELETE, OPTIONS',
+    config = require('../infrastructure/config'),
 
-    config, app, mobileApp;
+    app, mobileApp;
 
 describe('azure-mobile-apps.express.integration.cors', function () {
     beforeEach(function () {
-        config = {
+        app = express();
+        mobileApp = mobileApps(config.memory({
             cors: {
                 maxAge: 6000,
                 origins: ['localhost', { host: '*.v1.com' }, 'test.*.net']
-            },
-            skipVersionCheck: true
-        };
-        app = express();
-        mobileApp = mobileApps(config);
+            }
+        }));
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
     });

--- a/test/express/integration/customapi.tests.js
+++ b/test/express/integration/customapi.tests.js
@@ -3,14 +3,13 @@
 // ----------------------------------------------------------------------------
 var expect = require('chai').expect,
     request = require('supertest-as-promised'),
-    config = require('../infrastructure/config')(),
+    config = require('../infrastructure/config'),
     auth = require('../../../src/auth')({ secret: 'secret' }),
     token = auth.sign({ "uid": "Facebook:someuserid@hotmail.com" }),
     app, mobileApp;
 
     app = require('express')();
-    config.auth = { secret: 'secret', getIdentity: getIdentity };
-    mobileApp = require('../../../src/express')(config);
+    mobileApp = require('../../../src/express')(config.memory({ auth: { secret: 'secret', getIdentity: getIdentity }}));
 
     mobileApp.api.import('../files/api/customapi');
     mobileApp.api.import('../files/api/authapi');

--- a/test/express/integration/errors.tests.js
+++ b/test/express/integration/errors.tests.js
@@ -5,6 +5,7 @@ var expect = require('chai').expect,
     supertest = require('supertest-as-promised'),
     express = require('express'),
     mobileApps = require('../../..'),
+    config = require('../infrastructure/config'),
     app, mobileApp;
 
 describe('azure-mobile-apps.express.integration.errors', function () {
@@ -32,7 +33,7 @@ describe('azure-mobile-apps.express.integration.errors', function () {
 
     function setup(debug) {
         app = express();
-        mobileApp = mobileApps({ debug: debug, logging: false, skipVersionCheck: true });
+        mobileApp = mobileApps(config.memory({ debug: debug, logging: false }));
         var table = mobileApp.table();
         table.read.use(function (req, res, next) { throw new Error('test'); });
         mobileApp.tables.add('todoitem', table);

--- a/test/express/integration/middleware.tests.js
+++ b/test/express/integration/middleware.tests.js
@@ -3,12 +3,13 @@
 // ----------------------------------------------------------------------------
 var expect = require('chai').expect,
     supertest = require('supertest-as-promised'),
+    config = require('../infrastructure/config'),
     app = require('express')(),
     mobileApp;
 
 describe('azure-mobile-apps.express.integration.middleware', function () {
     before(function () {
-        mobileApp = require('../../..')({ skipVersionCheck: true }, {})
+        mobileApp = require('../../..')(config.memory())
     });
 
     it('read middleware is mounted in the correct order', function () {

--- a/test/express/integration/notifications.tests.js
+++ b/test/express/integration/notifications.tests.js
@@ -8,23 +8,20 @@ var sinon = require('sinon'),
         .expect,
     request = require('supertest-as-promised'),
     express = require('express'),
+    config = require('../infrastructure/config'),
     nhStub, notifFactoryStub, app, installation;
 
 
 var notificationMiddleware = require('../../../src/express/middleware/notifications');
 
-describe('azure-mobile-apps.express.integration.notifications', function () {
-    before(function () {
-        require('../../../src/logger').configure();
-    });
-    
+describe('azure-mobile-apps.express.integration.notifications', function () {    
     beforeEach(function () {
         installation = createInstallation();
 
         nhStub = createNHClientStub();
 
         app = express();
-        app.use('/push/installations', notificationMiddleware({ notifications: { client: nhStub }}));
+        app.use('/push/installations', notificationMiddleware(config.memory({ notifications: { client: nhStub }})));
     });
 
     it('returns 204 on successful creation', function () {

--- a/test/express/integration/tables.behavior.tests.js
+++ b/test/express/integration/tables.behavior.tests.js
@@ -5,7 +5,8 @@
     supertest = require('supertest-as-promised'),
     express = require('express'),
     bodyParser = require('body-parser'),
-    mobileApps = require('../../../src'),
+    config = require('../infrastructure/config'),
+    mobileApps = require('../../..'),
 
     app, mobileApp;
 
@@ -13,7 +14,7 @@
 describe('azure-mobile-apps.express.integration.tables.behavior', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ skipVersionCheck: true, logging: false }, {});
+        mobileApp = mobileApps(config.memory());
     });
 
     it('returns 200 for table route', function () {
@@ -46,7 +47,7 @@ describe('azure-mobile-apps.express.integration.tables.behavior', function () {
     it('returns 500 with error details when exception is thrown', function (done) {
         var table = mobileApp.table();
         table.read.use(function (req, res, next) { throw 'test'; });
-        mobileApp = mobileApps({ debug: true, skipVersionCheck: true, logging: false });
+        mobileApp = mobileApps(config.memory({ debug: true, logging: false }));
         mobileApp.tables.add('todoitem', table);
         app.use(mobileApp);
 
@@ -60,7 +61,7 @@ describe('azure-mobile-apps.express.integration.tables.behavior', function () {
     });
 
     it('returns 400 when request size limit is exceeded', function () {
-        mobileApp = mobileApps({ maxTop: 1000, logging: false });
+        mobileApp = mobileApps(config.memory({ maxTop: 1000}));
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -70,7 +71,7 @@ describe('azure-mobile-apps.express.integration.tables.behavior', function () {
     });
 
     it('returns 200 when request size limit is set to 0', function () {
-        mobileApp = mobileApps({ maxTop: 0, skipVersionCheck: true });
+        mobileApp = mobileApps(config.memory({ maxTop: 0 }));
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -87,7 +88,7 @@ describe('azure-mobile-apps.express.integration.tables.behavior', function () {
             query = context.query.toOData();
         });
 
-        mobileApp = mobileApps({ pageSize: 40, skipVersionCheck: true });
+        mobileApp = mobileApps(config.memory({ pageSize: 40, skipVersionCheck: true }));
         mobileApp.tables.add('todoitem', table);
         app.use(mobileApp);
 

--- a/test/express/integration/tables.concurrency.tests.js
+++ b/test/express/integration/tables.concurrency.tests.js
@@ -6,18 +6,18 @@ var expect = require('chai').use(require('chai-subset')).expect,
     express = require('express'),
     mobileApps = require('../../../src/express'),
     data = require('../../../src/data/mssql'),
-    config = require('../infrastructure/config').data(),
+    config = require('../infrastructure/config'),
 
     app, mobileApp;
 
 describe('azure-mobile-apps.express.sql.integration.tables.concurrency', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ data: config, skipVersionCheck: true });
+        mobileApp = mobileApps(config());
     });
 
     afterEach(function (done) {
-        data(config).execute({ sql: 'drop table concurrency' }).then(done, done);
+        data(config().data).execute({ sql: 'drop table concurrency' }).then(done, done);
     });
 
     it('returns 409 when version columns do not match', function () {

--- a/test/express/integration/tables.configuration.tests.js
+++ b/test/express/integration/tables.configuration.tests.js
@@ -5,6 +5,7 @@ var expect = require('chai').expect,
     supertest = require('supertest'),
     express = require('express'),
     mobileApps = require('../../../src/express'),
+    config = require('../infrastructure/config'),
 
     app, mobileApp;
 
@@ -12,7 +13,7 @@ var expect = require('chai').expect,
 describe('azure-mobile-apps.express.integration.tables.configuration', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ skipVersionCheck: true });
+        mobileApp = mobileApps(config.memory());
     });
 
     it('executes user code when provided', function (done) {
@@ -52,7 +53,7 @@ describe('azure-mobile-apps.express.integration.tables.configuration', function 
     });
 
     it('uses custom root path', function (done) {
-        mobileApp = mobileApps({ tableRootPath: '/test', skipVersionCheck: true });
+        mobileApp = mobileApps(config.memory({ tableRootPath: '/test' }));
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 

--- a/test/express/integration/tables.creation.tests.js
+++ b/test/express/integration/tables.creation.tests.js
@@ -3,7 +3,7 @@
 // ----------------------------------------------------------------------------
 var expect = require('chai').use(require('chai-subset')).expect,
     request = require('supertest-as-promised'),
-    config = require('../infrastructure/config').data(),
+    config = require('../infrastructure/config'),
     express = require('express'),
     mobileApps = require('../../../src/express'),
     data = require('../../../src/data/mssql'),
@@ -17,11 +17,11 @@ var expect = require('chai').use(require('chai-subset')).expect,
 describe('azure-mobile-apps.express.sql.integration.tables.creation', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ data: config, skipVersionCheck: true });
+        mobileApp = mobileApps(config());
     });
 
     afterEach(function (done) {
-        data(config).execute({ sql: 'drop table dbo.' + tableName }).then(done, done);
+        data(config().data).execute({ sql: 'drop table dbo.' + tableName }).then(done, done);
     });
 
     it('properly configures tables created via mobileApp.table', function () {

--- a/test/express/integration/tables.data.tests.js
+++ b/test/express/integration/tables.data.tests.js
@@ -8,26 +8,26 @@ var expect = require('chai')
     express = require('express'),
     mobileApps = require('../../../src'),
     data = require('../../../src/data/mssql'),
-    config = require('../infrastructure/config').data(),
+    config = require('../infrastructure/config'),
 
     app, mobileApp;
 
 describe('azure-mobile-apps.express.sql.integration.tables.data', function () {
     before(function (done) {
-        data(config)({ 
+        data(config.data())({ 
             name: 'integration', 
             columns: { string: 'string', number: 'number', bool: 'boolean' }
         }).initialize().then(done);
     });
 
     after(function (done) {
-        data(config).execute({ sql: 'DROP TABLE integration' }).then(done);
+        data(config.data()).execute({ sql: 'DROP TABLE integration' }).then(done);
     });
 
     beforeEach(function (done) {
         app = express();
-        mobileApp = mobileApps({ data: config, skipVersionCheck: true, logging: false });
-        data(config)({ name: 'integration' }).truncate().then(done);
+        mobileApp = mobileApps(config());
+        data(config.data())({ name: 'integration' }).truncate().then(done);
     });
 
     it('returns inserted records', function () {

--- a/test/express/integration/tables.dynamicSchema.tests.js
+++ b/test/express/integration/tables.dynamicSchema.tests.js
@@ -6,7 +6,7 @@ var expect = require('chai').use(require('chai-subset')).expect,
     express = require('express'),
     mobileApps = require('../../../src/express'),
     data = require('../../../src/data/mssql'),
-    config = require('../infrastructure/config').data(),
+    config = require('../infrastructure/config'),
     promises = require('../../../src/utilities/promises'),
 
     app, mobileApp;
@@ -14,11 +14,11 @@ var expect = require('chai').use(require('chai-subset')).expect,
 describe('azure-mobile-apps.express.sql.integration.tables.dynamicSchema', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ data: config, skipVersionCheck: true });
+        mobileApp = mobileApps(config());
     });
 
     afterEach(function (done) {
-        data(config).execute({ sql: 'drop table dynamic' }).then(done, done);
+        data(config.data()).execute({ sql: 'drop table dynamic' }).then(done, done);
     });
 
     it('creates table and returns inserted records', function () {

--- a/test/express/integration/tables.etag.tests.js
+++ b/test/express/integration/tables.etag.tests.js
@@ -5,6 +5,7 @@
     supertest = require('supertest-as-promised'),
     express = require('express'),
     mobileApps = require('../../../src'),
+    config = require('../infrastructure/config'),
 
     app, mobileApp;
 
@@ -12,7 +13,7 @@
 describe('azure-mobile-apps.express.integration.tables.etag', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ pageSize: 2, skipVersionCheck: true }, {});
+        mobileApp = mobileApps(config.memory({ pageSize: 2 }));
         var table = mobileApps.table();
         table.read(function (context) {
             return [{

--- a/test/express/integration/tables.initialize.tests.js
+++ b/test/express/integration/tables.initialize.tests.js
@@ -5,7 +5,7 @@
     supertest = require('supertest-as-promised'),
     express = require('express'),
     mobileApps = require('../../../src/express'),
-    config = require('../infrastructure/config').data(),
+    config = require('../infrastructure/config'),
     data = require('../../../src/data/mssql'),
     promises = require('../../../src/utilities/promises'),
 
@@ -19,7 +19,7 @@ describe('azure-mobile-apps.express.sql.integration.tables.initialize', function
         });
 
         afterEach(function (done) {
-            data(config).execute({ sql: 'drop table initialize' }).then(done, done);
+            data(config.data()).execute({ sql: 'drop table initialize' }).then(done, done);
         });
 
         it('creates non-dynamic tables', function () {
@@ -69,7 +69,7 @@ describe('azure-mobile-apps.express.sql.integration.tables.initialize', function
 
         function setup(columns) {
             app = express();
-            mobileApp = mobileApps({ skipVersionCheck: true, data: config });
+            mobileApp = mobileApps(config());
             mobileApp.tables.add('initialize', { dynamicSchema: false, columns: columns });
             app.use(mobileApp);
         }
@@ -78,7 +78,7 @@ describe('azure-mobile-apps.express.sql.integration.tables.initialize', function
     describe('concurrent initialization', function () {
         it('successfully initializes multiple tables concurrently', function () {
             app = express();
-            mobileApp = mobileApps({ skipVersionCheck: true, data: config });
+            mobileApp = mobileApps(config());
 
             var tables = [];
             for (var i = 0; i < 10; i++)
@@ -97,7 +97,7 @@ describe('azure-mobile-apps.express.sql.integration.tables.initialize', function
         }
 
         function drop(id) {
-            return data(config).execute({ sql: 'drop table table' + id });
+            return data(config.data()).execute({ sql: 'drop table table' + id });
         }
     })
 });

--- a/test/express/integration/tables.link.tests.js
+++ b/test/express/integration/tables.link.tests.js
@@ -5,6 +5,7 @@
     supertest = require('supertest-as-promised'),
     express = require('express'),
     mobileApps = require('../../../src'),
+    config = require('../infrastructure/config'),
 
     app, mobileApp;
 
@@ -12,11 +13,11 @@
 describe('azure-mobile-apps.express.integration.tables.link', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ pageSize: 2, skipVersionCheck: true }, {});
+        mobileApp = mobileApps(config.memory({ pageSize: 2 }));
     });
 
     it('adds Link header when top > pageSize & results.length === pageSize', function () {
-        mobileApp = mobileApps({ pageSize: 1, skipVersionCheck: true }, {});
+        mobileApp = mobileApps(config.memory({ pageSize: 1 }));
         mobileApp.tables.add('headers');
         app.use(mobileApp);
         return supertest(app)

--- a/test/express/integration/tables.softDelete.tests.js
+++ b/test/express/integration/tables.softDelete.tests.js
@@ -6,18 +6,18 @@ var expect = require('chai').use(require('chai-subset')).expect,
     express = require('express'),
     mobileApps = require('../../../src/express'),
     data = require('../../../src/data/mssql'),
-    config = require('../infrastructure/config').data(),
+    config = require('../infrastructure/config'),
 
     app, mobileApp;
 
 describe('azure-mobile-apps.express.sql.integration.tables.softDelete', function () {
     beforeEach(function () {
         app = express();
-        mobileApp = mobileApps({ data: config, skipVersionCheck: true });
+        mobileApp = mobileApps(config());
     });
 
     afterEach(function (done) {
-        data(config).execute({ sql: 'drop table softDelete' }).then(done, done);
+        data(config.data()).execute({ sql: 'drop table softDelete' }).then(done, done);
     });
 
     it('deleted records are not returned', function () {

--- a/test/express/integration/version.tests.js
+++ b/test/express/integration/version.tests.js
@@ -5,13 +5,14 @@ var expect = require('chai').expect,
     supertest = require('supertest-as-promised'),
     express = require('express'),
     mobileApps = require('../../..'),
+    config = require('../infrastructure/config'),
 
     app, mobileApp;
 
 describe('azure-mobile-apps.express.integration.version', function () {
     it('attaches server version header', function () {
         app = express();
-        mobileApp = mobileApps({ skipVersionCheck: true }, {});
+        mobileApp = mobileApps(config.memory());
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -22,7 +23,7 @@ describe('azure-mobile-apps.express.integration.version', function () {
 
     it('does not attach version header if version is set to undefined', function() {
         app = express();
-        mobileApp = mobileApps({ version: undefined, skipVersionCheck: true }, {});
+        mobileApp = mobileApps(config.memory({ version: undefined }));
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -35,7 +36,7 @@ describe('azure-mobile-apps.express.integration.version', function () {
 
     it('does not attach version header if MS_DisableVersionHeader is specified', function() {
         app = express();
-        mobileApp = mobileApps({ skipVersionCheck: true }, { MS_DisableVersionHeader: 'true' });
+        mobileApp = mobileApps(config.memory(), { MS_DisableVersionHeader: 'true' });
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -48,7 +49,7 @@ describe('azure-mobile-apps.express.integration.version', function () {
 
     it('returns 400 when appropriate api version is not specified', function () {
         app = express();
-        mobileApp = mobileApps();
+        mobileApp = mobileApps(config.memory({ skipVersionCheck: false }));
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -59,7 +60,7 @@ describe('azure-mobile-apps.express.integration.version', function () {
 
     it('succeeds when appropriate api version is specified in a header', function () {
         app = express();
-        mobileApp = mobileApps();
+        mobileApp = mobileApps(config.memory({ skipVersionCheck: false }));
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -71,7 +72,7 @@ describe('azure-mobile-apps.express.integration.version', function () {
 
     it('succeeds when appropriate api version is specified in a querystring', function () {
         app = express();
-        mobileApp = mobileApps();
+        mobileApp = mobileApps(config.memory({ skipVersionCheck: false }));
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -82,7 +83,7 @@ describe('azure-mobile-apps.express.integration.version', function () {
 
     it('ignores api version when skipVersionCheck is set in configuration', function () {
         app = express();
-        mobileApp = mobileApps({ skipVersionCheck: true });
+        mobileApp = mobileApps(config.memory());
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -93,7 +94,7 @@ describe('azure-mobile-apps.express.integration.version', function () {
 
     it('ignores api version when MS_SkipVersionCheck environment setting is specified', function () {
         app = express();
-        mobileApp = mobileApps(undefined, { MS_SkipVersionCheck: 'true' });
+        mobileApp = mobileApps(config.memory(), { MS_SkipVersionCheck: 'true' });
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 
@@ -104,7 +105,7 @@ describe('azure-mobile-apps.express.integration.version', function () {
 
     it("ignores api version when doing CORS preflight", function () {
         app = express();
-        mobileApp = mobileApps();
+        mobileApp = mobileApps(config.memory({ skipVersionCheck: false }));
         mobileApp.tables.add('todoitem');
         app.use(mobileApp);
 

--- a/test/setup.tests.js
+++ b/test/setup.tests.js
@@ -1,0 +1,6 @@
+var config = require('./express/infrastructure/config.js')() || {};
+var configureGlobals = require('../src').configureGlobals;
+
+beforeEach(function () {
+    configureGlobals(config);
+});


### PR DESCRIPTION
Couple things: 
- proposing a mocha file which configures globals before each test, which allows for testing within submodules with globals as created by config.
- added command line flags ---logging.level and ---promiseConstructor to set those values, respectively (was thinking about a generalized solution to set configuration values from the command line but it doesn't seem to have much value)

If this looks good I'll go through the tests and make sure that they're consuming the infrastructure config
