### PR TITLE
Updated package.json in all samples to use 2.0.0-beta2

### DIFF
--- a/samples/authentication/package.json
+++ b/samples/authentication/package.json
@@ -6,7 +6,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3"
     }
 }

--- a/samples/basic-app/package.json
+++ b/samples/basic-app/package.json
@@ -7,7 +7,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3"
     }
 }

--- a/samples/customApi/package.json
+++ b/samples/customApi/package.json
@@ -7,7 +7,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3"
     }
 }

--- a/samples/dynamic-schema/package.json
+++ b/samples/dynamic-schema/package.json
@@ -6,7 +6,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3"
     }
 }

--- a/samples/personal-table/package.json
+++ b/samples/personal-table/package.json
@@ -6,7 +6,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3"
     }
 }

--- a/samples/push-on-insert/package.json
+++ b/samples/push-on-insert/package.json
@@ -6,7 +6,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3"
     }
 }

--- a/samples/readonly-table/package.json
+++ b/samples/readonly-table/package.json
@@ -6,7 +6,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3"
     }
 }

--- a/samples/seeding-data/package.json
+++ b/samples/seeding-data/package.json
@@ -6,7 +6,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3"
     }
 }

--- a/samples/static-schema/package.json
+++ b/samples/static-schema/package.json
@@ -6,7 +6,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3"
     }
 }

--- a/samples/todo/package.json
+++ b/samples/todo/package.json
@@ -6,7 +6,7 @@
     "author": "Microsoft",
     "license": "MIT",
     "dependencies": {
-        "azure-mobile-apps": "^2.0.0-beta1",
+        "azure-mobile-apps": "^2.0.0-beta2",
         "express": "^4.13.3",
         "winston": "^2.1.1"
     }


### PR DESCRIPTION
This should be merged prior to shipping 2.0.0-beta2.  Packages won't work when upgraded unless there is a 2.0.0-beta2, so don't merge it until you are just about to release.