### PR TITLE
Only execute create if table does not exist

### DIFF
--- a/src/data/mssql/schema.js
+++ b/src/data/mssql/schema.js
@@ -13,14 +13,16 @@ module.exports = function (configuration) {
 
     var api = {
         initialize: function (table) {
-            return api.createTable(table)
-                .catch(function (error) {
-                    if(error.number === errorCodes.ObjectAlreadyExists)
+            return execute(configuration, statements.getColumns(table))
+                .then(function (columns) {
+                    if(columns.length === 0)
+                        return api.createTable(table)
+                            .catch(function (error) {
+                                log.error("Error occurred creating table " + table.name + ":", error);
+                                throw error;
+                            });
+                    else
                         return api.updateSchema(table);
-                    else {
-                        log.error("Error occurred creating table " + table.name + ":", error);
-                        throw error;
-                    }
                 });
         },
 


### PR DESCRIPTION
Not a perfect implementation as the getColumns query is executed twice when the table already exists, but this only happens on startup, so it's a very minor issue.