### PR TITLE
Data provider read now returns an array in all cases. Tests updated.

### DIFF
--- a/e2etest/tables/paramsTestTable.js
+++ b/e2etest/tables/paramsTestTable.js
@@ -2,8 +2,7 @@ var parameterTest = module.exports = require('azure-mobile-apps').table();
 
 parameterTest.autoIncrement = true;
 parameterTest.read(function (context) {
-    // read operations expect to return an array... this could be improved
-    return context.query.single ? mapParameters(context) : [mapParameters(context)];
+    return [mapParameters(context)];
 });
 parameterTest.insert(mapParameters);
 parameterTest.update(mapParameters);

--- a/src/data/contributor.md
+++ b/src/data/contributor.md
@@ -33,15 +33,24 @@ The `query` parameter is a [queryjs Query object][queryjs]. It exposes a LINQ st
 
 Support for conversion to other formats is currently limited to an OData object representation. This can be done using the `toOData` function exposed by the `azure-mobile-apps/src/query` module. See [the source][toOData].
 
-The read function should resolve to a result set that the Mobile Apps client SDK expects.
+The read function should resolve to an array of results.
 
-- For normal queries, this should be an array of results.
-- When the provided query has the `single` property set, this should be a single object.
-  If the item does not exist, it should resolve to undefined.
-- When the provided query has the `includeTotalCount` property set, this should be an object
-  with results and count properties.
+- When the provided query has the `includeTotalCount` property set, the array should have an
+  additional property `totalCount` set to the total number of records that would be returned
+  without a result size limit.
 - When the provided query has the `includeDeleted` property set, the results should include
   soft deleted items.
+
+### insert
+
+    function (item) { }
+
+The insert function should insert a new record into the database and resolve to the inserted item.
+
+- If an item with the same `id` property already exists, an `Error` should be thrown with
+  the `duplicate` property set.
+- The `createdAt` and `updatedAt` properties should be set to the current date and time.
+- The `version` property should be set to a unique value.
 
 ### update
 
@@ -58,17 +67,6 @@ and resolve to the updated item.
 - The `version` property should be updated to a new unique value.
 
 The `query` parameter is optional and allows filters such as user IDs to be applied to update operations. The query is in the format described in the read section.
-
-### insert
-
-    function (item) { }
-
-The insert function should insert a new record into the database and resolve to the inserted item.
-
-- If an item with the same `id` property already exists, an `Error` should be thrown with
-  the `duplicate` property set.
-- The `createdAt` and `updatedAt` properties should be set to the current date and time.
-- The `version` property should be set to a unique value.
 
 ### delete
 

--- a/src/data/mssql/statements/read.js
+++ b/src/data/mssql/statements/read.js
@@ -18,16 +18,12 @@ module.exports = function (source, tableConfig) {
     function transformResult(results) {
         log.silly('Read query returned ' + results[0].length + ' results');
 
+        var finalResults = helpers.translateVersion(results[0]);
+
         // if there is more than one result set, total count is the second query
-        if(results.length === 1) {
-            // if the query was for a single result, return a single result
-            var queryResults = source.single ? results[0][0] : results[0];
-            return helpers.translateVersion(queryResults);
-        } else {
-            return {
-                results: helpers.translateVersion(results[0]),
-                count: results[1][0].count
-            };
-        }
+        if(results.length > 1)
+            finalResults.totalCount = results[1][0].count;
+
+        return finalResults;
     }
 };

--- a/src/express/middleware/renderResults.js
+++ b/src/express/middleware/renderResults.js
@@ -7,11 +7,12 @@ var errors = require('../../utilities/errors'),
 ﻿// render results attached to response object to the client in JSON format
 module.exports = function (configuration) {
     return function (req, res, next) {
+        var single = req.method === 'GET' && req.azureMobile.query && req.azureMobile.query.single;
         preventCaching();
 
-        if(res.results) {
-            res.json(res.results);
-        } else
+        if(resultFound())
+            res.json(formatResultsForClient());
+        else
             next(errors.notFound());
 
         function preventCaching() {
@@ -21,6 +22,25 @@ module.exports = function (configuration) {
             res.set('cache-control', 'no-cache');
             res.set('expires', 0);
             res.set('pragma', 'no-cache');
+        }
+
+        function resultFound() {
+            if(single && res.results.constructor === Array)
+                return res.results.length > 0;
+            return !!(res.results);
+        }
+
+        function formatResultsForClient() {
+            if(single && res.results.constructor === Array)
+                return res.results[0];
+
+            if(res.results.constructor === Array && res.results.hasOwnProperty('totalCount'))
+                return {
+                    results: res.results,
+                    count: res.results.totalCount
+                };
+
+            return res.results;
         }
     };
 };

--- a/test/data/sql/integration.query.tests.js
+++ b/test/data/sql/integration.query.tests.js
@@ -11,8 +11,8 @@ var index = require('../../../src/data/mssql'),
 
 describe('azure-mobile-apps.data.sql.integration.query', function () {
     before(function (done) {
-        operations = index(config)({ 
-            name: 'query', 
+        operations = index(config)({
+            name: 'query',
             columns: { string: 'string', number: 'number', bool: 'boolean' },
             seed: [
                 { id: 1, string: 'one', number: 1, bool: 1 },
@@ -21,7 +21,7 @@ describe('azure-mobile-apps.data.sql.integration.query', function () {
                 { id: 4, string: 'four', number: 4, bool: 0 },
                 { id: 5, string: 'five', number: 5, bool: 1 },
                 { id: 6, string: 'six', number: 6, bool: 0 },
-            ]  
+            ]
         });
 
         operations.initialize()
@@ -64,20 +64,16 @@ describe('azure-mobile-apps.data.sql.integration.query', function () {
     it("returns total count if requested", function () {
         return operations.read(queries.create('query').where('number eq 3').includeTotalCount())
             .then(function (results) {
-                expect(results).to.containSubset({
-                    results: [{ bool: true, id: '3', number: 3, string: 'three' }],
-                    count: 1
-                });
+                expect(results).to.containSubset([{ bool: true, id: '3', number: 3, string: 'three' }]);
+                expect(results.totalCount).to.equal(1);
             });
     });
 
     it("returns total count for filter", function () {
         return operations.read(queries.create('query').take(1).includeTotalCount())
             .then(function (results) {
-                expect(results).to.containSubset({
-                    results: [{ bool: true, id: '1', number: 1, string: 'one' }],
-                    count: 6
-                });
+                expect(results).to.containSubset([{ bool: true, id: '1', number: 1, string: 'one' }]);
+                expect(results.totalCount).to.equal(6);
             });
     });
 });


### PR DESCRIPTION
Simplifies data provider implementation and user code - results are reliably an array, the transformation to a single result now happens in renderResults. User code can still return a single result.

Data providers now set a totalCount property on the result array if the includeTotalCount option is specified on the query.

@mamaso, you probably want to have a look.