### PR TITLE
Warn when import path does not exist, instead of crashing

### DIFF
--- a/src/configuration/loader.js
+++ b/src/configuration/loader.js
@@ -24,10 +24,12 @@ module.exports = {
             // get all files with supported extensions
             var filePaths = getFilePaths(filesPath);
 
-            if (filePaths.length)
+            if (filePaths.length) {
                 return loadFiles({}, filePaths);
-            else
-                throw new Error('Requested configuration path (' + fullPath + ') does not exist');
+            } else {
+                logger.warn('Requested configuration path (' + fullPath + ') does not exist');
+                return {};
+            }
         }
         else
             return loadDirectory({}, fullPath);

--- a/test/configuration/loader.tests.js
+++ b/test/configuration/loader.tests.js
@@ -72,6 +72,10 @@ describe('azure-mobile-apps.configuration.loader', function () {
         expect(table.func).to.have.property('json', true);
         expect(table.func.toString()).to.equal('function () { }');
     });
+
+    it('does not throw when target path does not exist', function () {
+        loader.loadPath('this/path/does/not/exist');
+    });
 });
 
 function requireWithRefresh(path) {

--- a/test/configuration/loader.tests.js
+++ b/test/configuration/loader.tests.js
@@ -74,7 +74,7 @@ describe('azure-mobile-apps.configuration.loader', function () {
     });
 
     it('does not throw when target path does not exist', function () {
-        loader.loadPath('this/path/does/not/exist');
+        expect(loader.loadPath('this/path/does/not/exist')).to.deep.equal({});
     });
 });
 


### PR DESCRIPTION
@mamaso minor change
@fabiocav this should unblock the scenario we were discussing with no other changes required

Resolves https://github.com/Azure/azure-mobile-apps-node/issues/347