### PR TITLE
Fixes for the typings field for typescript / VSCode in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.1",
   "description": "Build mobile apps with data storage, push notifications and offline sync in minutes.",
   "main": "src/index.js",
-  "typings": "typings/azure-mobile-apps/azure-mobile-apps.d.ts",
+  "typings": "typings/main.d.ts",
   "author": "Microsoft",
   "repository": "Azure/azure-mobile-apps-node",
   "license": "MIT",

--- a/typings/azure-mobile-apps/azure-mobile-apps.d.ts
+++ b/typings/azure-mobile-apps/azure-mobile-apps.d.ts
@@ -3,7 +3,9 @@
 // Definitions by: Microsoft Azure <https://github.com/Azure/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-/// <reference path="../express/express.d.ts" />
+// Express dependency must include express.d.ts manually - 
+//      tsd install express -so
+// Rremoving <reference path="../../../express/express.d.ts" />
 /// <reference path="../azure-sb/azure-sb.d.ts" />
 
 declare module "azure-mobile-apps" {

--- a/typings/main.d.ts
+++ b/typings/main.d.ts
@@ -1,0 +1,1 @@
+import "./azure-mobile-apps/azure-mobile-apps.d.ts"


### PR DESCRIPTION
Imports the ambient type definitions into a typed module (main.d.ts) and replaces the entry in the package.json file to use this file instead.  Also removes the local dependency on express.d.ts (assumes it has previously been imported by the user).

Relates to #374.