### PR TITLE
Fixed duplicate config/payload properties

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -62,10 +62,13 @@ var auth = require('azure-mobile-apps/src/auth')(mobileApp.configuration.auth);
 res.status(200).send(auth.sign({ sub: "myUserId" }));
         */
         sign: function (payload) {
-            var options = {
-                audience: configuration.audience || 'urn:microsoft:windows-azure:zumo',
-                issuer: configuration.issuer || 'urn:microsoft:windows-azure:zumo'
-            };
+            var options = { };
+
+            if(!payload.aud)
+                options.audience = configuration.audience || 'urn:microsoft:windows-azure:zumo';
+
+            if(!payload.iss)
+                options.issuer = configuration.issuer || 'urn:microsoft:windows-azure:zumo';
 
             if(!payload.exp)
                 options.expiresIn = (configuration.expires || 1440) * 60;

--- a/test/auth/auth.tests.js
+++ b/test/auth/auth.tests.js
@@ -26,10 +26,13 @@ describe('azure-mobile-apps.auth', function () {
             });
     });
 
-    it('payload expiry takes precedence over options', function () {
-        var auth = authModule({ secret: 'secret', expires: 1440 }),
-            token = auth.sign({ claim: 'claim', sub: 'id', exp: 9999999 });
+    it('payload expiry, issuer and audience takes precedence over options', function () {
+        var auth = authModule({ secret: 'secret', expires: 1440, audience: 'configAudience', issuer: 'configIssuer' }),
+            token = auth.sign({ claim: 'claim', sub: 'id', exp: 9999999, aud: 'payloadAudience', iss: 'payloadIssuer' }),
+            decodedClaims = auth.decode(token).claims;
 
-        expect(auth.decode(token).claims.exp).to.equal(9999999);
+        expect(decodedClaims.exp).to.equal(9999999);
+        expect(decodedClaims.aud).to.equal('payloadAudience');
+        expect(decodedClaims.iss).to.equal('payloadIssuer');
     });
 });


### PR DESCRIPTION
When version 6.2.0 of jsonwebtoken was introduced, it caused failures in decoding or validating tokens with a payload containing exp, aud or iss properties.