### PR TITLE
EasyAuth signing key specified with azureSigningKey

### DIFF
--- a/jsdoc/configuration.types.js
+++ b/jsdoc/configuration.types.js
@@ -68,7 +68,8 @@ SQLite data configuration.
 Authentication configuration
 @typedef authConfiguration
 @property {string} secret - Key to use to sign and validate JWT tokens
-@property {bool} validateTokens=false - By default, JWT tokens are only decoded as validation is handled by Azure Web Apps
+@property {string} azureSigningKey - Key to use to sign and validate JWT tokens, as taken from a hosted web apps WEBSITE_AUTH_SIGNING_KEY environment variable
+@property {bool} validateTokens - If the Azure Web App authentication is enabled, JWT tokens are only decoded as validation is already performed
 @property {string} audience=urn:microsoft:windows-azure:zumo - Token audience claim
 @property {string} issuer=urn:microsoft:windows-azure:zumo - Token issuer claim
 @property {integer} expiresInMinutes=1440 - Expiry of signed tokens

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -15,7 +15,7 @@ Create an instance of a helper based on the supplied configuration.
 @returns An object with members described below.
 */
 module.exports = function (configuration) {
-    var key = configuration.easyauth ? hexStringToBuffer(configuration.secret) : configuration.secret;
+    var key = configuration.azureSigningKey ? hexStringToBuffer(configuration.azureSigningKey) : configuration.secret;
 
     return {
         /**

--- a/src/configuration/defaults.js
+++ b/src/configuration/defaults.js
@@ -45,8 +45,7 @@ module.exports = function () {
             dynamicSchema: true
         },
         auth: {
-            secret: '0000',
-            validateTokens: false
+            secret: '0000'
         },
         notifications: { },
         storage: { }

--- a/src/configuration/from/environment.js
+++ b/src/configuration/from/environment.js
@@ -58,10 +58,6 @@ module.exports = function (configuration, environment) {
                 configuration.data.filename = environment[key];
                 break;
 
-            case 'website_auth_signing_key':
-                configuration.auth.secret = environment[key];
-                break;
-
             case 'ms_mobileappname':
             case 'ms_mobileservicename':
             case 'website_site_name':
@@ -105,8 +101,12 @@ module.exports = function (configuration, environment) {
                 break;
 
             case 'website_auth_enabled':
-                configuration.auth.easyauth = parseBoolean(environment[key]);
+                // if EasyAuth is enabled, it will be validating tokens for us
                 configuration.auth.validateTokens = !parseBoolean(environment[key]);
+                break;
+
+            case 'website_auth_signing_key':
+                configuration.auth.azureSigningKey = environment[key];
                 break;
 
             case 'customconnstr_ms_azurestorageaccountconnectionstring':

--- a/src/express/middleware/authenticate.js
+++ b/src/express/middleware/authenticate.js
@@ -40,7 +40,7 @@ module.exports = function (configuration) {
                 req.azureMobile = req.azureMobile || {};
                 req.azureMobile.auth = authUtils;
 
-                if(configuration.auth.validateTokens === true || !configuration.hosted) {
+                if(configuration.auth.validateTokens !== false) {
                     authUtils.validate(token)
                         .then(function (user) {
                             req.azureMobile.user = user;

--- a/test/auth/auth.tests.js
+++ b/test/auth/auth.tests.js
@@ -39,12 +39,12 @@ describe('azure-mobile-apps.auth', function () {
     it('handles hex encoded secrets', function () {
         var auth = authModule({ secret: 'abc' }),
             token = auth.sign({ sub: 'testUser' });
-        auth = authModule({ secret: '616263', easyauth: true });
+        auth = authModule({ azureSigningKey: '616263' });
         return auth.validate(token)
             .then(function (validated) {
                 expect(validated.id).to.equal('testUser');
 
-                auth = authModule({ secret: '616263', easyauth: true });
+                auth = authModule({ azureSigningKey: '616263' });
                 token = auth.sign({ sub: 'testUser' });
                 auth = authModule({ secret: 'abc' });
                 return auth.validate(token);

--- a/typings/azure-mobile-apps/azure-mobile-apps.d.ts
+++ b/typings/azure-mobile-apps/azure-mobile-apps.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Microsoft Azure <https://github.com/Azure/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-// Express dependency must include express.d.ts manually - 
+// Express dependency must include express.d.ts manually -
 //      tsd install express -so
 // Rremoving <reference path="../../../express/express.d.ts" />
 /// <reference path="../azure-sb/azure-sb.d.ts" />
@@ -154,8 +154,11 @@ declare module Azure.MobileApps {
         }
 
         interface Auth {
-            secret: string;
+            secret?: string;
+            azureSigningKey?: string;
             validateTokens?: boolean;
+            audience?: string;
+            issuer?: string;
         }
 
         interface Logging {


### PR DESCRIPTION
Previously, setting easyauth: true in auth config caused the secret to be hex decoded. Not intuitive. Signing keys taken from the WEBSITE_AUTH_SIGNING_KEY environment variable should now be specified in the azureSigningKey property of auth config.

validateTokens: false also now works as expected

@adrianhall I don't really see this as a "breaking change" as no production apps are affected (i.e. no update to 3.0.0 required). Do you agree with the config name azureSigningKey?

Resolves https://github.com/Azure/azure-mobile-apps-node/issues/444
Resolves https://github.com/Azure/azure-mobile-apps-node/issues/446