### PR TITLE
Fix swagger validation errors

### DIFF
--- a/src/swagger/tableOperation.js
+++ b/src/swagger/tableOperation.js
@@ -43,13 +43,6 @@ module.exports = function (configuration, schema) {
                 type: "string",
                 in: "path"
             },
-            'optionalId': {
-                name: "id",
-                description: "The record identifier. If not specified, the identifier will be determined from the provided item.",
-                required: false,
-                type: "string",
-                in: "path"
-            },
             'body': {
                 name: "body",
                 description: "The item",

--- a/src/swagger/tablePaths.js
+++ b/src/swagger/tablePaths.js
@@ -51,7 +51,7 @@ module.exports = function (configuration) {
             }),
             patch: createOperation({
                 summary: 'Update a record in the ' + schema.name + ' table',
-                parameters: ['optionalId', 'body'],
+                parameters: ['id', 'body'],
                 operation: 'Update',
                 responses: {
                     '200': createOperation.response('The updated item', 'item'),


### PR DESCRIPTION
Make /tables/tableName/id parameter mandatory for patch operations. A version of the path already exists without the id parameter, making effectively optional.

Resolves https://github.com/Azure/azure-mobile-apps-node/issues/465