### PR TITLE
Added status endpoint

### DIFF
--- a/src/express/index.js
+++ b/src/express/index.js
@@ -53,6 +53,9 @@ module.exports = function (configuration) {
             .use(middleware('crossOrigin'))
             .use(configuration.authStubRoute || '/.auth/login/:provider', middleware('authStub'));
 
+    if(configuration.statusEndpoint)
+        mobileApp.use('/status', middleware('status'));
+
     mobileApp
         .use(middleware('version'))
         .use(middleware('createContext'))

--- a/src/express/middleware/status.js
+++ b/src/express/middleware/status.js
@@ -1,0 +1,6 @@
+module.exports = function (configuration) {
+    return function (req, res, next) {
+        res.set('Access-Control-Allow-Origin', '*');
+        res.send({ status: 'Running' });
+    }
+}


### PR DESCRIPTION
Allows CORS from any origin to enable warming up the service from the Sonoma portal.

@pvbchak We'll need to get this deployed - it's just a blob that the data service gets deployed from isn't it?