### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "express": "^4.12.4",
     "jsonwebtoken": "^7.0.0",
     "mssql": "^3.2.0",
-    "node-uuid": "^1.4.7",
     "ua-parser": "^0.3.5",
+    "uuid": "^3.0.0",
     "winston": "^2.1.0"
   },
   "devDependencies": {

--- a/src/data/mssql/index.js
+++ b/src/data/mssql/index.js
@@ -9,7 +9,7 @@ var statements = require('./statements'),
     log = require('../../logger'),
     assert = require('../../utilities/assert').argument,
     queries = require('../../query'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 module.exports = function (configuration) {
     assert(configuration, 'Data configuration was not provided.');

--- a/src/data/mssql/schema.js
+++ b/src/data/mssql/schema.js
@@ -9,7 +9,7 @@ module.exports = function (configuration) {
         promises = require('../../utilities/promises'),
         log = require('../../logger'),
         helpers = require('./helpers'),
-        uuid = require('node-uuid');
+        uuid = require('uuid');
 
     var api = {
         initialize: function (table) {

--- a/src/data/sqlite/index.js
+++ b/src/data/sqlite/index.js
@@ -9,7 +9,7 @@ var statements = require('./statements'),
     connections = require('./connections'),
     log = require('../../logger'),
     queries = require('../../query'),
-    uuid = require('node-uuid');
+    uuid = require('uuid');
 
 module.exports = function (configuration) {
     configuration = configuration || {};

--- a/src/data/sqlite/schema.js
+++ b/src/data/sqlite/schema.js
@@ -8,7 +8,7 @@ module.exports = function (connection, serialize) {
         columns = require('./columns')(connection, serialize),
         promises = require('../../utilities/promises'),
         log = require('../../logger'),
-        uuid = require('node-uuid');
+        uuid = require('uuid');
 
     var api = {
         initialize: function (table) {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.