### PR TITLE
Return 404 for operations on soft deleted items

### DIFF
--- a/src/data/mssql/statements/undelete.js
+++ b/src/data/mssql/statements/undelete.js
@@ -22,6 +22,8 @@ module.exports = function (table, query, version) {
         sql: sql,
         parameters: parameters,
         multiple: true,
-        transform: helpers.statements.checkConcurrencyAndTranslate
+        transform: function (results) {
+            return helpers.statements.checkConcurrencyAndTranslate(results, undefined, true);
+        }
     };
 };

--- a/src/data/wrapProvider.js
+++ b/src/data/wrapProvider.js
@@ -26,6 +26,7 @@ module.exports = function (provider, table, context) {
         update: function (item, query) {
             assert(item, 'An item to update was not provided');
             query = createQuery(query);
+            if(table.softDelete) query.where({ deleted: false });
             var newContext = createContext('update', query, item);
             return tableAccess.update(apply.transforms(table, item, newContext), apply.filters(table, query, newContext))
                 .then(apply.hooks(newContext));
@@ -73,8 +74,13 @@ module.exports = function (provider, table, context) {
     }
 
     function createQuery(query) {
-        if(query && query.constructor !== queries.Query)
-            query = queries.create(table.name).where(query);
-        return query;
+        if(query && query.constructor === queries.Query)
+            return query;
+
+        var newQuery = queries.create(table.name);
+        if(query)
+            newQuery.where(query);
+
+        return newQuery;
     }
 };

--- a/test/express/integration/tables/operations.tests.js
+++ b/test/express/integration/tables/operations.tests.js
@@ -57,24 +57,6 @@ describe('azure-mobile-apps.express.integration.tables.operations', function () 
             .expect(200);
     });
 
-    it('applies filters to results of update operations', function () {
-        return supertest(app)
-            .delete('/tables/operations/1')
-            .expect(200)
-            .then(function () {
-                return supertest(app)
-                    .patch('/tables/operations/1')
-                    .send({ userId: '2' })
-                    .expect(200)
-            })
-            .then(function () {
-                // this succeeds in the test below, so we know the above update actually succeeded
-                return supertest(app)
-                    .post('/tables/operations/1')
-                    .expect(404)
-            });
-    });
-
     it('allows filters on deletes and behaves as normal when not filtered', function () {
         return supertest(app)
             .delete('/tables/operations/1')

--- a/test/express/integration/tables/softDelete.tests.js
+++ b/test/express/integration/tables/softDelete.tests.js
@@ -37,7 +37,7 @@ describe('azure-mobile-apps.express.integration.tables.softDelete', function () 
             })
             .then(function (results) {
                 expect(results.body.length).to.equal(0);
-            })
+            });
     });
 
     it('deleted records are returned when requested', function () {
@@ -60,7 +60,7 @@ describe('azure-mobile-apps.express.integration.tables.softDelete', function () 
             })
             .then(function (results) {
                 expect(results.body.length).to.equal(1);
-            })
+            });
     });
 
     it('deleted records can be undeleted', function () {
@@ -88,6 +88,41 @@ describe('azure-mobile-apps.express.integration.tables.softDelete', function () 
             })
             .then(function (results) {
                 expect(results.body.length).to.equal(1);
+            });
+    });
+
+    it('deleted records cannot be modified', function () {
+        mobileApp.tables.add('softDelete', { softDelete: true });
+        app.use(mobileApp);
+
+        return supertest(app)
+            .post('/tables/softDelete')
+            .send({ id: '1', value: 'test' })
+            .expect(201)
+            .then(function () {
+                return supertest(app)
+                    .delete('/tables/softDelete/1')
+                    .expect(200);
             })
-    })
+            .then(function () {
+                return supertest(app)
+                    .delete('/tables/softDelete/1')
+                    .expect(404);
+            })
+            .then(function () {
+                return supertest(app)
+                    .patch('/tables/softDelete/1')
+                    .send({ value: 'test2' })
+                    .expect(404);
+            })
+            .then(function () {
+                return supertest(app)
+                    .get('/tables/softDelete?__includeDeleted=true')
+                    .expect(200);
+            })
+            .then(function (results) {
+                expect(results.body.length).to.equal(1);
+                expect(results.body[0].value).to.equal('test');
+            });
+    });
 });


### PR DESCRIPTION
Data providers now throw notFound exception for operations on soft deleted items.

@shrishrirang should bring Node into line with .NET. I actually reckon this was the right change to make, rather than changing .NET. Things would have been simpler if I had this behavior in mind from the start, but oh well.

Resolves https://github.com/Azure/azure-mobile-apps-node/issues/497