### PR TITLE
Improve header next link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-mobile-apps",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Build mobile apps with data storage, push notifications and offline sync in minutes.",
   "main": "src/index.js",
   "typings": "typings/main.d.ts",

--- a/src/express/middleware/tables/nextLink.js
+++ b/src/express/middleware/tables/nextLink.js
@@ -36,7 +36,6 @@ nextLink.createLinkHeader = function (req, take, skip) {
         protocol: req.protocol,
         host: req.get('host'),
         pathname: req.baseUrl + req.path,
-        port: req.port,
         query: assign(req.query, { $top: take, $skip: skip })
     };
     var formattedUrl = formatUrl(urlObj);

--- a/src/express/middleware/tables/nextLink.js
+++ b/src/express/middleware/tables/nextLink.js
@@ -34,11 +34,11 @@ var nextLink = module.exports = function (table) {
 nextLink.createLinkHeader = function (req, take, skip) {
     var urlObj = {
         protocol: req.protocol,
-        hostname: req.hostname,
-        pathname: req.path,
+        host: req.get('host'),
+        pathname: req.baseUrl + req.path,
+        port: req.port,
         query: assign(req.query, { $top: take, $skip: skip })
     };
-
     var formattedUrl = formatUrl(urlObj);
 
     return formattedUrl + '; rel=next';

--- a/test/express/middleware/nextLink.tests.js
+++ b/test/express/middleware/nextLink.tests.js
@@ -14,8 +14,8 @@ describe('azure-mobile-apps.express.middleware.nextLink', function () {
             azureMobile: { query: queries.create('table').take(2) }
         };
         res = {
-            results: [ 1, 2 ],
-            headers: { },
+            results: [1, 2],
+            headers: {},
             set: function (key, value) {
                 this.headers[key] = value;
             }
@@ -50,7 +50,7 @@ describe('azure-mobile-apps.express.middleware.nextLink', function () {
     });
 
     it('creates link if results object contains total count', function () {
-        req.azureMobile.results = { results: [ 1, 2], count: 2 };
+        req.azureMobile.results = { results: [1, 2], count: 2 };
         nextLink(req, res, function () {
             expect(res.headers.Link).to.equal('http://host.com/tables/table?%24top=1&%24skip=2; rel=next');
         });
@@ -78,7 +78,16 @@ describe('azure-mobile-apps.express.middleware.nextLink', function () {
             var req = {
                 protocol: 'https',
                 hostname: 'host.net',
-                path: 'tables/table',
+                path: '',
+                baseUrl: '/tables/table',
+                get: function (value) {
+                    var res = '';
+                    if (value === 'host') {
+                        res = 'host.net';
+                    }
+
+                    return res;
+                },
                 query: {
                     "zumo-api-version": '2.0.0',
                     $filter: 'filters',


### PR DESCRIPTION
In some cases, the next link URL is not well formed:
- the port is not present in host
- req.path only return '/' instead of /table/xxx

